### PR TITLE
Rename change to update and remove to delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 ### Changed
+ - Rename endpoint macro `change` to `update` and `remove` to `delete`
  - All endpoints with a known operation verb (like `read` or `update`) now have an auto-generated operation id (`openapi` feature only)
  - Endpoint macros now place the rustdoc into the operation's description (`openapi` feature only)
  - Update `openapi_type` crate to 0.2.0

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ Assuming you assign `/foobar` to your resource, the following pre-defined endpoi
 | read          | id                 | GET       | /foobar/:id    |
 | search        | query              | GET       | /foobar/search |
 | create        | body               | POST      | /foobar        |
-| change_all    | body               | PUT       | /foobar        |
-| change        | id, body           | PUT       | /foobar/:id    |
-| remove_all    |                    | DELETE    | /foobar        |
-| remove        | id                 | DELETE    | /foobar/:id    |
+| update_all    | body               | PUT       | /foobar        |
+| update        | id, body           | PUT       | /foobar/:id    |
+| delete_all    |                    | DELETE    | /foobar        |
+| delete        | id                 | DELETE    | /foobar/:id    |
 
 Each of those endpoints has a macro that creates the neccessary boilerplate for the Resource. A
 simple example looks like this:

--- a/crates-io.md
+++ b/crates-io.md
@@ -34,10 +34,10 @@ Assuming you assign `/foobar` to your resource, the following pre-defined endpoi
 | read          | id                 | GET       | /foobar/:id    |
 | search        | query              | GET       | /foobar/search |
 | create        | body               | POST      | /foobar        |
-| change_all    | body               | PUT       | /foobar        |
-| change        | id, body           | PUT       | /foobar/:id    |
-| remove_all    |                    | DELETE    | /foobar        |
-| remove        | id                 | DELETE    | /foobar/:id    |
+| update_all    | body               | PUT       | /foobar        |
+| update        | id, body           | PUT       | /foobar/:id    |
+| delete_all    |                    | DELETE    | /foobar        |
+| delete        | id                 | DELETE    | /foobar/:id    |
 
 Each of those endpoints has a macro that creates the neccessary boilerplate for the Resource. A
 simple example looks like this:

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -102,22 +102,22 @@ pub fn create(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
-pub fn change_all(attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn update_all(attr: TokenStream, item: TokenStream) -> TokenStream {
 	expand_macro(attr, item, |attr, item| expand_endpoint(EndpointType::UpdateAll, attr, item))
 }
 
 #[proc_macro_attribute]
-pub fn change(attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn update(attr: TokenStream, item: TokenStream) -> TokenStream {
 	expand_macro(attr, item, |attr, item| expand_endpoint(EndpointType::Update, attr, item))
 }
 
 #[proc_macro_attribute]
-pub fn remove_all(attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn delete_all(attr: TokenStream, item: TokenStream) -> TokenStream {
 	expand_macro(attr, item, |attr, item| expand_endpoint(EndpointType::DeleteAll, attr, item))
 }
 
 #[proc_macro_attribute]
-pub fn remove(attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn delete(attr: TokenStream, item: TokenStream) -> TokenStream {
 	expand_macro(attr, item, |attr, item| expand_endpoint(EndpointType::Delete, attr, item))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,10 @@ Assuming you assign `/foobar` to your resource, the following pre-defined endpoi
 | read          | id                 | GET       | /foobar/:id    |
 | search        | query              | GET       | /foobar/search |
 | create        | body               | POST      | /foobar        |
-| change_all    | body               | PUT       | /foobar        |
-| change        | id, body           | PUT       | /foobar/:id    |
-| remove_all    |                    | DELETE    | /foobar        |
-| remove        | id                 | DELETE    | /foobar/:id    |
+| update_all    | body               | PUT       | /foobar        |
+| update        | id, body           | PUT       | /foobar/:id    |
+| delete_all    |                    | DELETE    | /foobar        |
+| delete        | id                 | DELETE    | /foobar/:id    |
 
 Each of those endpoints has a macro that creates the neccessary boilerplate for the Resource. A
 simple example looks like this:

--- a/tests/async_methods.rs
+++ b/tests/async_methods.rs
@@ -20,7 +20,7 @@ mod util {
 use util::{test_delete_response, test_get_response, test_post_response, test_put_response};
 
 #[derive(Resource)]
-#[resource(read_all, read, search, create, change_all, change, remove_all, remove, state_test)]
+#[resource(read_all, read, search, create, update_all, update, delete_all, delete, state_test)]
 struct FooResource;
 
 #[derive(Deserialize)]
@@ -61,28 +61,28 @@ async fn create(_body: FooBody) -> Raw<&'static [u8]> {
 	Raw::new(CREATE_RESPONSE, TEXT_PLAIN)
 }
 
-const CHANGE_ALL_RESPONSE: &[u8] = b"QlbYg8gHE9OQvvk3yKjXJLTSXlIrg9mcqhfMXJmQkv";
-#[change_all]
-async fn change_all(_body: FooBody) -> Raw<&'static [u8]> {
-	Raw::new(CHANGE_ALL_RESPONSE, TEXT_PLAIN)
+const UPDATE_ALL_RESPONSE: &[u8] = b"QlbYg8gHE9OQvvk3yKjXJLTSXlIrg9mcqhfMXJmQkv";
+#[update_all]
+async fn update_all(_body: FooBody) -> Raw<&'static [u8]> {
+	Raw::new(UPDATE_ALL_RESPONSE, TEXT_PLAIN)
 }
 
-const CHANGE_RESPONSE: &[u8] = b"qGod55RUXkT1lgPO8h0uVM6l368O2S0GrwENZFFuRu";
-#[change]
-async fn change(_id: u64, _body: FooBody) -> Raw<&'static [u8]> {
-	Raw::new(CHANGE_RESPONSE, TEXT_PLAIN)
+const UPDATE_RESPONSE: &[u8] = b"qGod55RUXkT1lgPO8h0uVM6l368O2S0GrwENZFFuRu";
+#[update]
+async fn update(_id: u64, _body: FooBody) -> Raw<&'static [u8]> {
+	Raw::new(UPDATE_RESPONSE, TEXT_PLAIN)
 }
 
-const REMOVE_ALL_RESPONSE: &[u8] = b"Y36kZ749MRk2Nem4BedJABOZiZWPLOtiwLfJlGTwm5";
-#[remove_all]
-async fn remove_all() -> Raw<&'static [u8]> {
-	Raw::new(REMOVE_ALL_RESPONSE, TEXT_PLAIN)
+const DELETE_ALL_RESPONSE: &[u8] = b"Y36kZ749MRk2Nem4BedJABOZiZWPLOtiwLfJlGTwm5";
+#[delete_all]
+async fn delete_all() -> Raw<&'static [u8]> {
+	Raw::new(DELETE_ALL_RESPONSE, TEXT_PLAIN)
 }
 
-const REMOVE_RESPONSE: &[u8] = b"CwRzBrKErsVZ1N7yeNfjZuUn1MacvgBqk4uPOFfDDq";
-#[remove]
-async fn remove(_id: u64) -> Raw<&'static [u8]> {
-	Raw::new(REMOVE_RESPONSE, TEXT_PLAIN)
+const DELETE_RESPONSE: &[u8] = b"CwRzBrKErsVZ1N7yeNfjZuUn1MacvgBqk4uPOFfDDq";
+#[delete]
+async fn delete(_id: u64) -> Raw<&'static [u8]> {
+	Raw::new(DELETE_RESPONSE, TEXT_PLAIN)
 }
 
 const STATE_TEST_RESPONSE: &[u8] = b"xxJbxOuwioqR5DfzPuVqvaqRSfpdNQGluIvHU4n1LM";
@@ -118,16 +118,16 @@ fn async_methods() {
 		"http://localhost/foo",
 		r#"{"data":"hello world"}"#,
 		APPLICATION_JSON,
-		CHANGE_ALL_RESPONSE
+		UPDATE_ALL_RESPONSE
 	);
 	test_put_response(
 		&server,
 		"http://localhost/foo/1",
 		r#"{"data":"hello world"}"#,
 		APPLICATION_JSON,
-		CHANGE_RESPONSE
+		UPDATE_RESPONSE
 	);
-	test_delete_response(&server, "http://localhost/foo", REMOVE_ALL_RESPONSE);
-	test_delete_response(&server, "http://localhost/foo/1", REMOVE_RESPONSE);
+	test_delete_response(&server, "http://localhost/foo", DELETE_ALL_RESPONSE);
+	test_delete_response(&server, "http://localhost/foo/1", DELETE_RESPONSE);
 	test_get_response(&server, "http://localhost/foo/state_test", STATE_TEST_RESPONSE);
 }

--- a/tests/cors_handling.rs
+++ b/tests/cors_handling.rs
@@ -6,21 +6,20 @@ use gotham::{
 	test::{Server, TestRequest, TestServer}
 };
 use gotham_restful::{
-	change_all,
 	cors::{Headers, Origin},
-	read_all, CorsConfig, DrawResources, Raw, Resource
+	read_all, update_all, CorsConfig, DrawResources, Raw, Resource
 };
 use mime::TEXT_PLAIN;
 
 #[derive(Resource)]
-#[resource(read_all, change_all)]
+#[resource(read_all, update_all)]
 struct FooResource;
 
 #[read_all]
 fn read_all() {}
 
-#[change_all]
-fn change_all(_body: Raw<Vec<u8>>) {}
+#[update_all]
+fn update_all(_body: Raw<Vec<u8>>) {}
 
 fn test_server(cfg: CorsConfig) -> TestServer {
 	let (chain, pipeline) = single_pipeline(new_pipeline().add(cfg).build());

--- a/tests/openapi_specification.rs
+++ b/tests/openapi_specification.rs
@@ -37,7 +37,7 @@ fn get_image(_id: u64) -> Raw<&'static [u8]> {
 	Raw::new(IMAGE_RESPONSE, "image/png;base64".parse().unwrap())
 }
 
-#[change(operation_id = "setImage")]
+#[update(operation_id = "setImage")]
 fn set_image(_id: u64, _image: Image) {}
 
 #[derive(Resource)]

--- a/tests/sync_methods.rs
+++ b/tests/sync_methods.rs
@@ -14,7 +14,7 @@ mod util {
 use util::{test_delete_response, test_get_response, test_post_response, test_put_response};
 
 #[derive(Resource)]
-#[resource(read_all, read, search, create, change_all, change, remove_all, remove)]
+#[resource(read_all, read, search, create, update_all, update, delete_all, delete)]
 struct FooResource;
 
 #[derive(Deserialize)]
@@ -55,28 +55,28 @@ fn create(_body: FooBody) -> Raw<&'static [u8]> {
 	Raw::new(CREATE_RESPONSE, TEXT_PLAIN)
 }
 
-const CHANGE_ALL_RESPONSE: &[u8] = b"QlbYg8gHE9OQvvk3yKjXJLTSXlIrg9mcqhfMXJmQkv";
-#[change_all]
-fn change_all(_body: FooBody) -> Raw<&'static [u8]> {
-	Raw::new(CHANGE_ALL_RESPONSE, TEXT_PLAIN)
+const UPDATE_ALL_RESPONSE: &[u8] = b"QlbYg8gHE9OQvvk3yKjXJLTSXlIrg9mcqhfMXJmQkv";
+#[update_all]
+fn update_all(_body: FooBody) -> Raw<&'static [u8]> {
+	Raw::new(UPDATE_ALL_RESPONSE, TEXT_PLAIN)
 }
 
-const CHANGE_RESPONSE: &[u8] = b"qGod55RUXkT1lgPO8h0uVM6l368O2S0GrwENZFFuRu";
-#[change]
-fn change(_id: u64, _body: FooBody) -> Raw<&'static [u8]> {
-	Raw::new(CHANGE_RESPONSE, TEXT_PLAIN)
+const UPDATE_RESPONSE: &[u8] = b"qGod55RUXkT1lgPO8h0uVM6l368O2S0GrwENZFFuRu";
+#[update]
+fn update(_id: u64, _body: FooBody) -> Raw<&'static [u8]> {
+	Raw::new(UPDATE_RESPONSE, TEXT_PLAIN)
 }
 
-const REMOVE_ALL_RESPONSE: &[u8] = b"Y36kZ749MRk2Nem4BedJABOZiZWPLOtiwLfJlGTwm5";
-#[remove_all]
-fn remove_all() -> Raw<&'static [u8]> {
-	Raw::new(REMOVE_ALL_RESPONSE, TEXT_PLAIN)
+const DELETE_ALL_RESPONSE: &[u8] = b"Y36kZ749MRk2Nem4BedJABOZiZWPLOtiwLfJlGTwm5";
+#[delete_all]
+fn delete_all() -> Raw<&'static [u8]> {
+	Raw::new(DELETE_ALL_RESPONSE, TEXT_PLAIN)
 }
 
-const REMOVE_RESPONSE: &[u8] = b"CwRzBrKErsVZ1N7yeNfjZuUn1MacvgBqk4uPOFfDDq";
-#[remove]
-fn remove(_id: u64) -> Raw<&'static [u8]> {
-	Raw::new(REMOVE_RESPONSE, TEXT_PLAIN)
+const DELETE_RESPONSE: &[u8] = b"CwRzBrKErsVZ1N7yeNfjZuUn1MacvgBqk4uPOFfDDq";
+#[delete]
+fn delete(_id: u64) -> Raw<&'static [u8]> {
+	Raw::new(DELETE_RESPONSE, TEXT_PLAIN)
 }
 
 #[test]
@@ -103,15 +103,15 @@ fn sync_methods() {
 		"http://localhost/foo",
 		r#"{"data":"hello world"}"#,
 		APPLICATION_JSON,
-		CHANGE_ALL_RESPONSE
+		UPDATE_ALL_RESPONSE
 	);
 	test_put_response(
 		&server,
 		"http://localhost/foo/1",
 		r#"{"data":"hello world"}"#,
 		APPLICATION_JSON,
-		CHANGE_RESPONSE
+		UPDATE_RESPONSE
 	);
-	test_delete_response(&server, "http://localhost/foo", REMOVE_ALL_RESPONSE);
-	test_delete_response(&server, "http://localhost/foo/1", REMOVE_RESPONSE);
+	test_delete_response(&server, "http://localhost/foo", DELETE_ALL_RESPONSE);
+	test_delete_response(&server, "http://localhost/foo/1", DELETE_RESPONSE);
 }


### PR DESCRIPTION
This was done initially because of a naming conflict with diesel. However, now that registering methods works through the function name, this can be undone again.