### PR TITLE
Improve UI when AuthData does not implement Clone

### DIFF
--- a/derive/src/endpoint.rs
+++ b/derive/src/endpoint.rs
@@ -671,10 +671,8 @@ fn expand_endpoint_type(
 		let mut state_block = quote!();
 		if let Some(arg) = args.iter().find(|arg| arg.ty.is_auth_status()) {
 			let auth_ty = arg.ty.quote_ty();
-			let auth_borrow = quote_spanned! { auth_ty.span() =>
-				<#auth_ty as ::core::clone::Clone>::clone(
-					<#auth_ty as ::gotham_restful::gotham::state::FromState>::borrow_from(state)
-				)
+			let auth_borrow = quote! {
+				::gotham_restful::private::clone_from_state::<#auth_ty>(state)
 			};
 			state_block = quote! {
 				#state_block

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,15 +489,21 @@ pub use gotham_restful_derive::*;
 #[doc(hidden)]
 pub mod private {
 	pub use crate::routing::PathExtractor as IdPlaceholder;
-
 	pub use futures_util::future::{BoxFuture, FutureExt};
-
-	pub use serde_json;
-
 	#[cfg(feature = "database")]
 	pub use gotham_middleware_diesel::Repo;
 	#[cfg(feature = "openapi")]
 	pub use openapi_type::{OpenapiSchema, OpenapiType, Visitor};
+	pub use serde_json;
+
+	use gotham::state::{FromState, State};
+
+	pub fn clone_from_state<T>(state: &State) -> T
+	where
+		T: FromState + Clone
+	{
+		T::borrow_from(state).clone()
+	}
 }
 
 #[cfg(feature = "auth")]

--- a/tests/ui/endpoint/auth_data_non_clone.stderr
+++ b/tests/ui/endpoint/auth_data_non_clone.stderr
@@ -1,11 +1,16 @@
-error[E0277]: the trait bound `gotham_restful::AuthStatus<AuthData>: Clone` is not satisfied
+error[E0277]: the trait bound `AuthData: Clone` is not satisfied
   --> tests/ui/endpoint/auth_data_non_clone.rs:15:25
    |
 15 | async fn read_all(auth: AuthStatus<AuthData>) -> Result<NoContent, AuthError> {
-   |                         ^^^^^^^^^^ the trait `Clone` is not implemented for `gotham_restful::AuthStatus<AuthData>`
+   |                         ^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `AuthData`
    |
    = note: required for `gotham_restful::AuthStatus<AuthData>` to implement `Clone`
-help: consider borrowing here
+note: required by a bound in `clone_from_state`
+  --> src/lib.rs
    |
-15 | async fn read_all(auth: &AuthStatus<AuthData>) -> Result<NoContent, AuthError> {
-   |                         +
+   |         T: FromState + Clone
+   |                        ^^^^^ required by this bound in `clone_from_state`
+help: consider annotating `AuthData` with `#[derive(Clone)]`
+    |
+9   | #[derive(Clone)]
+    |


### PR DESCRIPTION
The error message regressed between Rust 1.64 and 1.66, adding the suggestion to borrow the parameter. We always clone the auth data in the endpoint macro, so this suggestions is very misleading. This PR avoids the suggestion, at least when using Rust 1.66.