### PR TITLE
Improve UI when the custom schema fn accepts the wrong argument

### DIFF
--- a/derive/src/endpoint.rs
+++ b/derive/src/endpoint.rs
@@ -537,15 +537,10 @@ fn expand_endpoint_type(
 		let status_codes_fn = status_codes.unwrap_or_else(|| unreachable!());
 
 		let schema_call = quote_spanned! { schema_fn.span() =>
-			let schema = ::gotham_restful::private::invoke::<_,
-				::gotham_restful::gotham::hyper::StatusCode,
-				::gotham_restful::private::OpenapiSchema
-			>(#schema_fn, code);
+			let schema = ::gotham_restful::private::CustomSchema::schema(#schema_fn, code);
 		};
 		let status_codes_call = quote_spanned! { status_codes_fn.span() =>
-			let status_codes: ::std::vec::Vec<
-				::gotham_restful::gotham::hyper::StatusCode
-			> = #status_codes_fn();
+			let status_codes = ::gotham_restful::private::CustomStatusCodes::status_codes(#status_codes_fn);
 		};
 
 		quote! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,13 +496,14 @@ pub mod private {
 	pub use openapi_type::{OpenapiSchema, OpenapiType, Visitor};
 	pub use serde_json;
 
-	use gotham::{
-		hyper::StatusCode,
-		state::{FromState, State}
-	};
+	#[cfg(feature = "openapi")]
+	use gotham::hyper::StatusCode;
+	#[cfg(feature = "auth")]
+	use gotham::state::{FromState, State};
 
 	/// This method is used by the endpoint macro to generate a good error message
 	/// when the used AuthData type does not implement Clone.
+	#[cfg(feature = "auth")]
 	#[inline]
 	pub fn clone_from_state<T>(state: &State) -> T
 	where
@@ -513,14 +514,17 @@ pub mod private {
 
 	/// This trait is used by the endpoint macro to generate a good error message
 	/// when the schema function has the wrong signature.
+	#[cfg(feature = "openapi")]
 	pub trait CustomSchema {
 		fn schema(self, code: StatusCode) -> OpenapiSchema;
 	}
 
+	#[cfg(feature = "openapi")]
 	impl<F> CustomSchema for F
 	where
 		F: FnOnce(StatusCode) -> OpenapiSchema
 	{
+		#[inline]
 		fn schema(self, code: StatusCode) -> OpenapiSchema {
 			self(code)
 		}
@@ -528,14 +532,17 @@ pub mod private {
 
 	/// This trait is used by the endpoint macro to generate a good error message
 	/// when the status_codes function has the wrong signature.
+	#[cfg(feature = "openapi")]
 	pub trait CustomStatusCodes {
 		fn status_codes(self) -> Vec<StatusCode>;
 	}
 
+	#[cfg(feature = "openapi")]
 	impl<F> CustomStatusCodes for F
 	where
 		F: FnOnce() -> Vec<StatusCode>
 	{
+		#[inline]
 		fn status_codes(self) -> Vec<StatusCode> {
 			self()
 		}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,11 +498,24 @@ pub mod private {
 
 	use gotham::state::{FromState, State};
 
+	/// This method is used by the endpoint macro to generate a good error message
+	/// when the used AuthData type does not implement Clone.
+	#[inline]
 	pub fn clone_from_state<T>(state: &State) -> T
 	where
 		T: FromState + Clone
 	{
 		T::borrow_from(state).clone()
+	}
+
+	/// This method is used by the endpoint macro to generate a good error message
+	/// when the schema function accepts the wrong argument.
+	#[inline]
+	pub fn invoke<F, T, U>(f: F, arg: T) -> U
+	where
+		F: FnOnce(T) -> U
+	{
+		f(arg)
 	}
 }
 

--- a/tests/ui/endpoint/dynamic_schema_wrong_type.stderr
+++ b/tests/ui/endpoint/dynamic_schema_wrong_type.stderr
@@ -9,20 +9,14 @@ error[E0631]: type mismatch in function arguments
    |
    = note: expected function signature `fn(StatusCode) -> _`
               found function signature `fn(u16) -> _`
-note: required by a bound in `invoke`
-  --> src/lib.rs
-   |
-   |         F: FnOnce(T) -> U
-   |            ^^^^^^^^^^^^^^ required by this bound in `invoke`
+   = note: required for `fn(u16) -> std::string::String {schema}` to implement `CustomSchema`
 
-error[E0308]: mismatched types
+error[E0271]: expected `fn() -> Vec<u16> {status_codes}` to be a fn item that returns `Vec<StatusCode>`, but it returns `Vec<u16>`
   --> tests/ui/endpoint/dynamic_schema_wrong_type.rs:16:46
    |
 16 | #[read_all(schema = "schema", status_codes = "status_codes")]
-   |                                              ^^^^^^^^^^^^^^
-   |                                              |
-   |                                              expected struct `StatusCode`, found `u16`
-   |                                              expected due to this
+   |                                              ^^^^^^^^^^^^^^ expected struct `StatusCode`, found `u16`
    |
    = note: expected struct `Vec<StatusCode>`
               found struct `Vec<u16>`
+   = note: required for `fn() -> Vec<u16> {status_codes}` to implement `CustomStatusCodes`

--- a/tests/ui/endpoint/dynamic_schema_wrong_type.stderr
+++ b/tests/ui/endpoint/dynamic_schema_wrong_type.stderr
@@ -1,30 +1,19 @@
-error[E0308]: mismatched types
+error[E0631]: type mismatch in function arguments
   --> tests/ui/endpoint/dynamic_schema_wrong_type.rs:16:21
-   |
-16 | #[read_all(schema = "schema", status_codes = "status_codes")]
-   |                     ^^^^^^^^
-   |                     |
-   |                     expected `u16`, found struct `StatusCode`
-   |                     arguments to this function are incorrect
-   |
-note: function defined here
-  --> tests/ui/endpoint/dynamic_schema_wrong_type.rs:8:4
    |
 8  | fn schema(_: u16) -> String {
-   |    ^^^^^^ ------
-help: call `Into::into` on this expression to convert `StatusCode` into `u16`
-   |
-16 | #[read_all(schema = "schema".into(), status_codes = "status_codes")]
-   |                             +++++++
-
-error[E0308]: mismatched types
-  --> tests/ui/endpoint/dynamic_schema_wrong_type.rs:16:21
-   |
+   | --------------------------- found signature defined here
+...
 16 | #[read_all(schema = "schema", status_codes = "status_codes")]
-   |                     ^^^^^^^^
-   |                     |
-   |                     expected struct `OpenapiSchema`, found struct `std::string::String`
-   |                     expected due to this
+   |                     ^^^^^^^^ expected due to this
+   |
+   = note: expected function signature `fn(StatusCode) -> _`
+              found function signature `fn(u16) -> _`
+note: required by a bound in `invoke`
+  --> src/lib.rs
+   |
+   |         F: FnOnce(T) -> U
+   |            ^^^^^^^^^^^^^^ required by this bound in `invoke`
 
 error[E0308]: mismatched types
   --> tests/ui/endpoint/dynamic_schema_wrong_type.rs:16:46


### PR DESCRIPTION
The error message regressed between Rust 1.64 and 1.66, adding the suggestion to call .into() on the macro invokation.