### PR TITLE
Use function name as operation verb if operation id is missing

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "openapi")]
+use crate::openapi::operation::OperationId;
 use crate::{IntoResponse, RequestBody};
 use futures_util::future::BoxFuture;
 use gotham::{
@@ -89,8 +91,8 @@ pub trait Endpoint {
 	/// Replace the automatically generated operation id with a custom one. Only relevant for the
 	/// OpenAPI Specification.
 	#[openapi_only]
-	fn operation_id() -> Option<String> {
-		None
+	fn operation_id() -> OperationId {
+		OperationId::FullAuto
 	}
 
 	/// Add a description to the openapi specification. Usually taken from the rustdoc comment

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,7 +564,7 @@ pub use cors::{handle_cors, CorsConfig, CorsRoute};
 #[cfg(feature = "openapi")]
 mod openapi;
 #[cfg(feature = "openapi")]
-pub use openapi::{builder::OpenapiInfo, router::GetOpenapi};
+pub use openapi::{builder::OpenapiInfo, operation::OperationId, router::GetOpenapi};
 
 mod endpoint;
 #[cfg(feature = "openapi")]

--- a/src/openapi/operation.rs
+++ b/src/openapi/operation.rs
@@ -10,7 +10,7 @@ use openapi_type::{
 	},
 	OpenapiSchema
 };
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 fn new_parameter_data(
 	name: String,
@@ -93,6 +93,17 @@ impl OperationParams {
 	}
 }
 
+#[derive(Debug, Default)]
+pub enum OperationId {
+	/// Automatically generate the operation id based on path and operation verb.
+	#[default]
+	FullAuto,
+	/// Automatically generate the operation id based on path and the provided string.
+	SemiAuto(Cow<'static, str>),
+	/// Use the provided operation id.
+	Manual(String)
+}
+
 pub(crate) struct OperationDescription {
 	operation_id: Option<String>,
 	description: Option<String>,
@@ -112,10 +123,18 @@ impl OperationDescription {
 		responses: HashMap<StatusCode, ReferenceOr<Schema>>,
 		path: &str
 	) -> Self {
-		let operation_id = E::operation_id().or_else(|| {
-			E::operation_verb()
-				.map(|verb| format!("{verb}_{}", path.replace("/", "_").trim_start_matches('_')))
-		});
+		let (mut operation_id, op_id_verb) = match E::operation_id() {
+			OperationId::FullAuto => (None, E::operation_verb().map(Cow::Borrowed)),
+			OperationId::SemiAuto(verb) => (None, Some(verb)),
+			OperationId::Manual(id) => (Some(id), None)
+		};
+		if let Some(verb) = op_id_verb {
+			operation_id = Some(format!(
+				"{verb}_{}",
+				path.replace('/', "_").trim_start_matches('_')
+			));
+		}
+
 		Self {
 			operation_id,
 			description: E::description(),

--- a/src/openapi/operation.rs
+++ b/src/openapi/operation.rs
@@ -129,10 +129,13 @@ impl OperationDescription {
 			OperationId::Manual(id) => (Some(id), None)
 		};
 		if let Some(verb) = op_id_verb {
-			operation_id = Some(format!(
-				"{verb}_{}",
-				path.replace('/', "_").trim_start_matches('_')
-			));
+			let op_path = path.replace('/', "_");
+			let op_path = op_path.trim_start_matches('_');
+			if verb.starts_with(op_path) || verb.ends_with(op_path) {
+				operation_id = Some(verb.into_owned());
+			} else {
+				operation_id = Some(format!("{verb}_{op_path}"));
+			}
 		}
 
 		Self {

--- a/tests/openapi_specification.json
+++ b/tests/openapi_specification.json
@@ -46,7 +46,7 @@
   "paths": {
     "/coffee": {
       "get": {
-        "operationId": "read_all_coffee",
+        "operationId": "coffee_read_all",
         "responses": {
           "418": {
             "content": {
@@ -64,6 +64,7 @@
     },
     "/custom": {
       "patch": {
+        "operationId": "custom_patch",
         "requestBody": {
           "content": {
             "application/json": {
@@ -83,6 +84,7 @@
     },
     "/custom/read/{from}/with/{id}": {
       "get": {
+        "operationId": "custom_read_with",
         "parameters": [
           {
             "in": "path",


### PR DESCRIPTION
Closes #44 